### PR TITLE
Fix navigation issue with page header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="index.html">
+            <a class="navbar-brand" href="/index.html">
               <img src="{{ site.baseurl }}/img/logo.png" alt="Logo">
             </a>
           </div>


### PR DESCRIPTION
## Issue
When viewing a blog post, and clicking the logo in the page header, the user will be sent to a 404 page instead of the index.

## My fix
I just added a `/`to the path to fix the issue (changes `index.html` to `/index.html`)